### PR TITLE
chore(deps): bump lru from 0.16.3 to 0.18.1 in nitrite-fjall-adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,6 +1837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lsm-tree"
 version = "2.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,7 +2009,7 @@ dependencies = [
  "dashmap",
  "fjall",
  "log",
- "lru 0.16.3",
+ "lru 0.18.1",
  "nitrite",
  "parking_lot 0.12.5",
  "thiserror",

--- a/nitrite-fjall-adapter/Cargo.toml
+++ b/nitrite-fjall-adapter/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.14"
 cargo_toml = "0.22.1"
 dashmap = "6.1.0"
 crossbeam = "0.8.4"
-lru = "0.16.3"
+lru = "0.18.1"
 parking_lot = "0.12.4"
 thiserror = "2.0"
 


### PR DESCRIPTION
## Summary
- Cherry-picked out of #9: bumps `lru` 0.16.3 -> 0.18.1 in `nitrite-fjall-adapter`, fixing an open low-severity Dependabot advisory.
- Left the `rand` 0.8.5 -> 0.9.2 bump out of this PR (see #8 / #10) since it breaks the build for unrelated reasons.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p nitrite_fjall_adapter` — 233 passed