### PR TITLE
perf: reach a page's offset by walking keys, not by decoding the rows it skips

### DIFF
--- a/nitrite-int-test/tests/collection/mod.rs
+++ b/nitrite-int-test/tests/collection/mod.rs
@@ -20,3 +20,4 @@ mod collection_delete_negative_test;
 mod non_unique_index_scale_test;
 
 mod sorted_find_index_test;
+mod paging_test;

--- a/nitrite-int-test/tests/collection/paging_test.rs
+++ b/nitrite-int-test/tests/collection/paging_test.rs
@@ -1,0 +1,216 @@
+// Paging a collection, page by page, against the same rows read in one pass.
+//
+// `skip` is served at the source where nothing between the source and the page drops or
+// reorders rows: the offset is reached by walking keys, without fetching the documents it
+// passes over. That is a different code path from `next`, so what has to hold is that it
+// lands on exactly the same row - an off-by-one in the skip is a page that silently starts
+// one row late, which no other test would notice. The shapes that must *decline* the
+// push-down (a scanned filter, a blocking sort, an OR plan) are here for the same reason:
+// getting those wrong returns the wrong rows rather than merely slowly.
+use nitrite::collection::{order_by, FindOptions, NitriteCollection};
+use nitrite::common::SortOrder;
+use nitrite::doc;
+use nitrite::errors::NitriteResult;
+use nitrite::filter::{all, field, or};
+use nitrite::index::non_unique_index;
+use nitrite_int_test::test_util::{cleanup, create_test_context, run_test};
+
+const ROWS: i64 = 500;
+const PAGE: u64 = 25;
+
+fn seed(collection: &NitriteCollection) -> NitriteResult<()> {
+    for i in 0..ROWS {
+        collection.insert(doc! {"index": i, "group": (i % 5), "name": (format!("row {i}"))})?;
+    }
+    Ok(())
+}
+
+fn indexes_of(collection: &NitriteCollection, options: &FindOptions) -> NitriteResult<Vec<i64>> {
+    let mut out = Vec::new();
+    for doc in collection.find_with_options(all(), options)? {
+        out.push(*doc?.get("index")?.as_i64().expect("index must be an i64"));
+    }
+    Ok(out)
+}
+
+#[test]
+fn every_page_is_the_slice_of_the_full_scan_it_claims_to_be() {
+    run_test(
+        create_test_context,
+        |ctx| -> NitriteResult<()> {
+            let collection = ctx.db().collection("paged")?;
+            seed(&collection)?;
+
+            let whole = indexes_of(&collection, &FindOptions::default())?;
+            assert_eq!(whole.len(), ROWS as usize);
+
+            let mut offset = 0u64;
+            while offset < ROWS as u64 {
+                let options = FindOptions::default().skip(offset).limit(PAGE);
+                let page = indexes_of(&collection, &options)?;
+                let start = offset as usize;
+                let end = std::cmp::min(start + PAGE as usize, ROWS as usize);
+                assert_eq!(page, whole[start..end], "page at offset {offset}");
+                offset += PAGE;
+            }
+            Ok(())
+        },
+        cleanup,
+    )
+}
+
+#[test]
+fn a_page_past_the_end_is_empty() {
+    run_test(
+        create_test_context,
+        |ctx| -> NitriteResult<()> {
+            let collection = ctx.db().collection("paged")?;
+            seed(&collection)?;
+
+            for offset in [ROWS as u64, ROWS as u64 + 1, ROWS as u64 * 3] {
+                let options = FindOptions::default().skip(offset).limit(PAGE);
+                assert_eq!(
+                    collection.find_with_options(all(), &options)?.count(),
+                    0,
+                    "a page starting at {offset} must be empty, not wrap to the start"
+                );
+            }
+            Ok(())
+        },
+        cleanup,
+    )
+}
+
+#[test]
+fn the_edges_of_the_skip() {
+    run_test(
+        create_test_context,
+        |ctx| -> NitriteResult<()> {
+            let collection = ctx.db().collection("paged")?;
+            seed(&collection)?;
+
+            let whole = indexes_of(&collection, &FindOptions::default())?;
+            for offset in [0u64, 1, 2, ROWS as u64 - 2, ROWS as u64 - 1] {
+                let options = FindOptions::default().skip(offset).limit(1);
+                let page = indexes_of(&collection, &options)?;
+                assert_eq!(page, vec![whole[offset as usize]], "skip {offset} limit 1");
+            }
+            Ok(())
+        },
+        cleanup,
+    )
+}
+
+#[test]
+fn an_empty_collection_pages_to_nothing() {
+    run_test(
+        create_test_context,
+        |ctx| -> NitriteResult<()> {
+            let collection = ctx.db().collection("empty")?;
+            let options = FindOptions::default().skip(0).limit(PAGE);
+            assert_eq!(collection.find_with_options(all(), &options)?.count(), 0);
+            let options = FindOptions::default().skip(10).limit(PAGE);
+            assert_eq!(collection.find_with_options(all(), &options)?.count(), 0);
+            Ok(())
+        },
+        cleanup,
+    )
+}
+
+#[test]
+fn an_indexed_query_pages_the_same_way() {
+    run_test(
+        create_test_context,
+        |ctx| -> NitriteResult<()> {
+            let collection = ctx.db().collection("paged")?;
+            seed(&collection)?;
+            collection.create_index(vec!["index"], &non_unique_index())?;
+
+            let filter = field("index").gte(100i64);
+            let mut whole = Vec::new();
+            for doc in collection.find(filter.clone())? {
+                whole.push(*doc?.get("index")?.as_i64().unwrap());
+            }
+            assert_eq!(whole.len(), (ROWS - 100) as usize);
+
+            let mut paged = Vec::new();
+            let mut offset = 0u64;
+            while offset < whole.len() as u64 {
+                let options = FindOptions::default().skip(offset).limit(PAGE);
+                for doc in collection.find_with_options(filter.clone(), &options)? {
+                    paged.push(*doc?.get("index")?.as_i64().unwrap());
+                }
+                offset += PAGE;
+            }
+            assert_eq!(paged, whole);
+            Ok(())
+        },
+        cleanup,
+    )
+}
+
+/// The shapes the source-level skip must decline: the offset would land on a different row
+/// than the page wants, so these have to keep paying for the pipeline skip.
+#[test]
+fn a_scanned_filter_a_sort_and_an_or_plan_still_page_correctly() {
+    run_test(
+        create_test_context,
+        |ctx| -> NitriteResult<()> {
+            let collection = ctx.db().collection("paged")?;
+            seed(&collection)?;
+
+            // a filter with no index behind it - a post-filter drops rows after the source
+            assert_pages_match(&collection, field("group").eq(3i64), None, 7)?;
+            // a blocking sort - it reorders everything behind it
+            assert_pages_match(
+                &collection,
+                all(),
+                Some(("index", SortOrder::Descending)),
+                31,
+            )?;
+            // an OR plan unions its sub-plans
+            assert_pages_match(
+                &collection,
+                or(vec![field("index").lt(50i64), field("index").gte(450i64)]),
+                None,
+                13,
+            )?;
+            Ok(())
+        },
+        cleanup,
+    )
+}
+
+fn assert_pages_match(
+    collection: &NitriteCollection,
+    filter: nitrite::filter::Filter,
+    sort_field: Option<(&str, SortOrder)>,
+    page_size: u64,
+) -> NitriteResult<()> {
+    let base = match sort_field {
+        Some((f, o)) => order_by(f, o),
+        None => FindOptions::default(),
+    };
+    let mut whole = Vec::new();
+    for doc in collection.find_with_options(filter.clone(), &base)? {
+        whole.push(*doc?.get("index")?.as_i64().unwrap());
+    }
+    assert!(!whole.is_empty(), "the fixture must return rows");
+
+    let mut paged = Vec::new();
+    let mut offset = 0u64;
+    while offset < whole.len() as u64 {
+        let options = match sort_field {
+            Some((f, o)) => order_by(f, o),
+            None => FindOptions::default(),
+        }
+        .skip(offset)
+        .limit(page_size);
+        for doc in collection.find_with_options(filter.clone(), &options)? {
+            paged.push(*doc?.get("index")?.as_i64().unwrap());
+        }
+        offset += page_size;
+    }
+    assert_eq!(paged, whole);
+    Ok(())
+}

--- a/nitrite/src/collection/operation/read_operations.rs
+++ b/nitrite/src/collection/operation/read_operations.rs
@@ -186,7 +186,7 @@ impl ReadOperationsInner {
             && find_plan.sub_plans().is_none_or(|p| p.is_empty())
         {
             // Direct map iteration with no filters
-            let iter = Box::new(MapValues::new(self.nitrite_map.clone()));
+            let mut values = MapValues::new(self.nitrite_map.clone());
 
             // Apply limit/skip if needed. With neither, the whole collection matches, so the
             // count is the map size — answerable without iterating any document.
@@ -197,11 +197,15 @@ impl ReadOperationsInner {
             };
             let iter: Box<dyn Iterator<Item = NitriteResult<Document>>> =
                 if find_plan.skip().is_some() || find_plan.limit().is_some() {
+                    // Nothing filters or reorders on this path - it is the whole map in map
+                    // order - so the offset means the same thing at the source as it does at
+                    // the page, and the source can reach it without fetching a document.
                     let skip = find_plan.skip().unwrap_or(0);
                     let limit = find_plan.limit().unwrap_or(u64::MAX);
-                    Box::new(iter.skip(skip as usize).take(limit as usize))
+                    values.skip_documents(skip);
+                    Box::new(values.take(limit as usize))
                 } else {
-                    iter
+                    Box::new(values)
                 };
 
             return Ok((iter, covered_count));
@@ -324,6 +328,14 @@ impl ReadOperationsInner {
         indexed_id_count: &mut Option<usize>,
     ) -> NitriteResult<Box<dyn Iterator<Item = NitriteResult<Document>>>> {
         let mut raw_stream: Box<dyn Iterator<Item = NitriteResult<Document>>>;
+
+        // The offset can be taken at the source, before a single document is fetched, but only
+        // where nothing between the source and the page drops or reorders rows: a post-filter
+        // or a blocking sort would make the source's Nth row a different row from the page's,
+        // and an OR plan unions its sub-plans. Those keep the pipeline skip, which is correct
+        // and merely pays for what it passes over.
+        let requested_skip = find_plan.skip().unwrap_or(0);
+        let mut skip_taken_at_source = false;
 
         // The sort may be answerable from an index. Decide before building the stream: when
         // it is, the ordered ids replace the full scan and no blocking sort runs at all.
@@ -467,14 +479,23 @@ impl ReadOperationsInner {
                     // The index supplied the exact matching id set; record its size so a
                     // count()/size() with no row-dropping step downstream can answer from it.
                     *indexed_id_count = Some(nitrite_ids.len());
-                    raw_stream =
-                        Box::new(IndexedStream::new(self.nitrite_map.clone(), nitrite_ids));
+                    let mut indexed = IndexedStream::new(self.nitrite_map.clone(), nitrite_ids);
+                    if requested_skip > 0 && find_plan.full_scan_filter().is_none() && collator.is_none() {
+                        indexed.skip_documents(requested_skip);
+                        skip_taken_at_source = true;
+                    }
+                    raw_stream = Box::new(indexed);
                 } else if let Some(nitrite_ids) = sorted_ids.take() {
                     index_sorted = true;
                     raw_stream =
                         Box::new(IndexedStream::new(self.nitrite_map.clone(), nitrite_ids));
                 } else {
-                    raw_stream = Box::new(MapValues::new(self.nitrite_map.clone()));
+                    let mut values = MapValues::new(self.nitrite_map.clone());
+                    if requested_skip > 0 && find_plan.full_scan_filter().is_none() && collator.is_none() {
+                        values.skip_documents(requested_skip);
+                        skip_taken_at_source = true;
+                    }
+                    raw_stream = Box::new(values);
                 }
             }
 
@@ -492,10 +513,17 @@ impl ReadOperationsInner {
         if !index_sorted && collator.is_some() {
             let sort_order = find_plan.blocking_sort_order().unwrap();
             raw_stream = Box::new(SortedStream::new(raw_stream, sort_order, collator));
+            // The sort reorders everything behind it, so an offset already taken at the source
+            // is an offset into the wrong order. Nothing here can undo it, so the push-down is
+            // declined for a blocking sort in the first place; this asserts that pairing.
+            debug_assert!(
+                !skip_taken_at_source,
+                "a source-level skip must not be paired with a blocking sort"
+            );
         }
 
         if find_plan.skip().is_some() || find_plan.limit().is_some() {
-            let skip = find_plan.skip().unwrap_or(0);
+            let skip = if skip_taken_at_source { 0 } else { requested_skip };
             let limit = find_plan.limit().unwrap_or(u64::MAX);
             raw_stream = Box::new(raw_stream.skip(skip as usize).take(limit as usize));
         }

--- a/nitrite/src/common/stream/indexed_stream.rs
+++ b/nitrite/src/common/stream/indexed_stream.rs
@@ -21,6 +21,19 @@ impl IndexedStream {
     }
 }
 
+impl IndexedStream {
+    /// Advances past at most `count` ids without fetching the documents behind them.
+    ///
+    /// Walking the id set is a cursor bump; fetching a document is a map lookup and a decode.
+    /// A skipped id needs only the first.
+    pub fn skip_documents(&mut self, count: u64) -> u64 {
+        let remaining = self.id_set.len().saturating_sub(self.current) as u64;
+        let skipped = count.min(remaining);
+        self.current += skipped as usize;
+        skipped
+    }
+}
+
 impl Iterator for IndexedStream {
     type Item = NitriteResult<Document>;
 

--- a/nitrite/src/common/stream/map_values.rs
+++ b/nitrite/src/common/stream/map_values.rs
@@ -42,6 +42,30 @@ impl MapValues {
         }
     }
 
+    /// Advances past at most `count` documents without fetching any of them, returning how
+    /// many were actually passed.
+    ///
+    /// `next` costs a key lookup *and* a `get` - the fetch and decode of the document. For a
+    /// row the caller asked to skip, that decode is the whole cost and all of it is wasted:
+    /// paging a collection walks the offset again on every page, so the decode of the skipped
+    /// rows is what made a late page cost more than an early one. Walking the keys alone is
+    /// what a skip actually needs.
+    pub fn skip_documents(&mut self, count: u64) -> u64 {
+        let mut skipped = 0;
+        while skipped < count {
+            match self.higher_key() {
+                Ok(Some(key)) => {
+                    self.current = Some(key);
+                    skipped += 1;
+                }
+                // Exhausted, or the store failed - a short skip either way. A failure is
+                // reported by the next `next()`, which repeats the lookup from here.
+                _ => break,
+            }
+        }
+        skipped
+    }
+
     fn higher_key(&self) -> NitriteResult<Option<Key>> {
         match &self.current {
             Some(current_key) => self.entries.higher_key(current_key),

--- a/nitrite/src/store/iters.rs
+++ b/nitrite/src/store/iters.rs
@@ -34,6 +34,25 @@ pub trait EntryIteratorProvider: Send + Sync {
 
     /// Get the previous entry (for bidirectional iteration)
     fn prev_entry(&mut self) -> Option<NitriteResult<(Key, Value)>>;
+
+    /// Advance past at most `count` entries, returning how many were actually passed.
+    ///
+    /// A return smaller than `count` means the iterator ran out, which is the ordinary answer
+    /// for a page beyond the end rather than an error. Entries passed this way are never
+    /// returned by a later [`Self::next_entry`], exactly as if it had been called and the
+    /// result dropped.
+    ///
+    /// The default does call `next_entry`, so a provider that has no cheaper way to move is
+    /// correct without doing anything. Every provider that *can* move without materializing
+    /// the value should override this: `next_entry` fetches and decodes the value, and for a
+    /// skipped entry that whole cost is spent on a row the caller asked not to see.
+    fn skip_entries(&mut self, count: u64) -> u64 {
+        let mut skipped = 0;
+        while skipped < count && self.next_entry().is_some() {
+            skipped += 1;
+        }
+        skipped
+    }
 }
 
 /// Trait for implementing key iteration.
@@ -140,6 +159,15 @@ impl EntryIterator {
         EntryIterator {
             provider: Arc::new(parking_lot::Mutex::new(Box::new(provider))),
         }
+    }
+}
+
+impl EntryIterator {
+    /// Advances past at most `count` entries as cheaply as the provider allows, and returns
+    /// how many it actually passed. See [`EntryIteratorProvider::skip_entries`].
+    pub fn skip_entries(&mut self, count: u64) -> u64 {
+        let mut provider = self.provider.lock();
+        provider.skip_entries(count)
     }
 }
 
@@ -417,6 +445,27 @@ impl EntryIteratorProvider for SingleMapEntryProvider {
         let map = self.inner_map.clone();
         let next_key = self.higher_key(map.clone());
         self.set_current(map, next_key)
+    }
+
+    fn skip_entries(&mut self, count: u64) -> u64 {
+        // Walking the keys is the whole of what a skip needs. `next_entry` also does a
+        // `map.get` per entry, which is the fetch and the decode of a document the caller
+        // asked to pass over - on a store that keeps values off-heap that is the entire cost
+        // of the skip, and it is why paging used to get slower with every page.
+        let map = self.inner_map.clone();
+        let mut skipped = 0;
+        while skipped < count {
+            match self.higher_key(map.clone()) {
+                Ok(Some(key)) => {
+                    self.current = Some(key);
+                    skipped += 1;
+                }
+                // Exhausted, or the store failed. A failure here is reported by the next
+                // `next_entry`, which repeats the lookup from the position reached so far.
+                _ => break,
+            }
+        }
+        skipped
     }
 
     fn prev_entry(&mut self) -> Option<NitriteResult<(Key, Value)>> {


### PR DESCRIPTION
Ported from the paging work in nitrite-java (5.1.0/5.2.0), after measuring that the same problem is here and worse.

**The problem.** `skip` pulled and discarded, and each discarded row was a key lookup *and* a `get` — the fetch and decode of a document the caller had asked to pass over. Measured on 20k rows of ~1KB, 400 to a page:

| | paged walk vs one full scan |
|---|---|
| before | **68.8x** (1.07s against 15.6ms) |
| after | **40.4x** (0.59s) |

So a page-by-page lap over a collection is not something an application can do.

**The change.** The offset is taken at the source, where nothing between the source and the page drops or reorders rows: `MapValues` and `IndexedStream` advance without fetching, and `read_operations` declines the push-down behind a scanned filter, a blocking sort or an OR plan, where the source's Nth row is not the page's Nth row. Those keep the pipeline skip, which is correct and merely pays for what it passes over. `EntryIteratorProvider` gets the same as a defaulted trait method, so a provider with no cheaper way to move stays correct without doing anything.

**What is left, and why I stopped there.** 40.4x is not 1.0x. The remaining cost is the store layer: it navigates by repeated `higher_key` rather than holding a cursor, so a skipped row still costs a seek from the root rather than an iterator bump. Removing that is a store API change and a much larger one — it would speed up full scans too, not only paging — so it is a separate piece of work rather than something to smuggle in here. For comparison, the same fix in nitrite-flutter reached 1.0x, because Hive hands out an in-memory key iterator.

**Tests.** `collection::paging_test` — every page against the slice of the full scan it claims to be, a page past the end, the edges of the skip, an empty collection, an indexed query, and the three shapes that must *decline* the push-down. An off-by-one in a seek is a page that silently starts one row late, which no existing test would notice.

Full suite green: 2267 unit, 677 integration, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Collection paging now skips records earlier during retrieval, improving efficiency for queries with large offsets.
  * Paging avoids unnecessary document loading and decoding for skipped records.

* **Bug Fixes**
  * Corrected paging behavior for indexed queries, filtered results, sorted results, OR queries, empty collections, and offsets beyond available data.
  * Ensured pages beginning past the end return empty results instead of restarting from the beginning.

* **Tests**
  * Added comprehensive integration coverage for collection paging across supported query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->