### PR TITLE
perf: skip a page's offset over keys alone, not over a seek per row

### DIFF
--- a/nitrite-fjall-adapter/src/map.rs
+++ b/nitrite-fjall-adapter/src/map.rs
@@ -306,6 +306,19 @@ impl NitriteMapProvider for FjallMap {
     /// Returns an iterator over all entries in this map.
     ///
     /// Returns: An `EntryIterator` for iteration
+    /// Steps the partition's key iterator, which reads keys without their values.
+    ///
+    /// The walk this replaces asks the LSM tree for the next key from scratch each time - a
+    /// range seek per row - and it is paid again from zero on every page. Stepping one key
+    /// iterator is a move within the block it is already positioned on.
+    ///
+    /// Declined while a transaction is in scope: the keys there have to include the scope's
+    /// own uncommitted inserts and exclude its tombstones, which is what `visible_entry_raw`
+    /// merges. A count over the committed partition alone would land on the wrong row.
+    fn skip_keys_from_start(&self, count: u64) -> NitriteResult<Option<(u64, Option<Key>)>> {
+        self.inner.skip_keys_from_start(count)
+    }
+
     fn entries(&self) -> NitriteResult<EntryIterator> {
         let provider = SingleMapEntryProvider::new(NitriteMap::new(self.clone()));
         Ok(EntryIterator::new(provider))
@@ -541,6 +554,33 @@ impl FjallMapInner {
                 .map(Self::decode_bytes)
                 .transpose()
         })
+    }
+
+    fn skip_keys_from_start(&self, count: u64) -> NitriteResult<Option<(u64, Option<Key>)>> {
+        self.check_opened()?;
+        if crate::tx_scope::in_scope() {
+            return Ok(None);
+        }
+
+        let mut keys = self.partition.inner().keys();
+        let mut skipped = 0u64;
+        let mut landed: Option<Vec<u8>> = None;
+        while skipped < count {
+            match keys.next() {
+                Some(Ok(key)) => {
+                    landed = Some(key.to_vec());
+                    skipped += 1;
+                }
+                Some(Err(err)) => return Err(Self::backend_err("skip keys in", err)),
+                None => break,
+            }
+        }
+
+        // Only the key it stopped on is decoded - the ones stepped over never become Keys.
+        let landed = landed
+            .map(|key| Self::decode_value(FjallValue::from(key)))
+            .transpose()?;
+        Ok(Some((skipped, landed)))
     }
 
     fn committed_entry_raw(

--- a/nitrite/src/common/stream/map_values.rs
+++ b/nitrite/src/common/stream/map_values.rs
@@ -51,6 +51,15 @@ impl MapValues {
     /// rows is what made a late page cost more than an early one. Walking the keys alone is
     /// what a skip actually needs.
     pub fn skip_documents(&mut self, count: u64) -> u64 {
+        // Only from the start, which is where a page offset is applied. `current` is None
+        // there; anything else has already begun walking and must carry on walking.
+        if self.current.is_none() {
+            if let Ok(Some((skipped, landed))) = self.entries.skip_keys_from_start(count) {
+                self.current = landed;
+                return skipped;
+            }
+        }
+
         let mut skipped = 0;
         while skipped < count {
             match self.higher_key() {

--- a/nitrite/src/store/nitrite_map.rs
+++ b/nitrite/src/store/nitrite_map.rs
@@ -263,6 +263,21 @@ pub trait NitriteMapProvider: AttributeAware + Send + Sync {
     /// # Returns
     /// * `Ok(EntryIterator)` with an iterator over all entries
     /// * `Err(NitriteError)` if the operation fails
+    /// Steps past the first `count` keys from the beginning of the map without reading the
+    /// values behind them, returning how many were passed and the key it landed on.
+    ///
+    /// The default returns `None`, meaning "I have no cheaper way to do this" - the caller then
+    /// walks `first_key`/`higher_key`, which is correct and costs a seek per key. A store whose
+    /// keys can be iterated without touching values should implement this: paging re-walks the
+    /// offset on every page, so that seek is paid once per skipped row per page.
+    ///
+    /// Only supported from the start of the map, which is what a page offset needs. A store
+    /// that cannot honour an open transaction's uncommitted writes here must return `None`
+    /// rather than a position that disagrees with `get`.
+    fn skip_keys_from_start(&self, _count: u64) -> NitriteResult<Option<(u64, Option<Key>)>> {
+        Ok(None)
+    }
+
     fn entries(&self) -> NitriteResult<EntryIterator>;
 
     /// Retrieves a reverse iterator over all key-value entries in the map.


### PR DESCRIPTION
Follows #24, which stopped the skip fetching documents but left it asking the store for the next key from scratch each time — a range seek into the LSM tree per skipped row, paid again from zero on every page.

Fjall can iterate keys without reading the values behind them (`partition.keys()`), so stepping that iterator is a move inside the block it already sits on.

**First, a correction to #24's numbers.** They were quoted against `find(all()).count()`, and an unfiltered `count()` is answered from the map size without reading a single document — so the denominator was near zero and every ratio was inflated about 4x. The absolute times were right. Measured properly, against a full scan that is *drained*:

| | paged walk | vs a real full scan |
|---|---|---|
| before #24 | 1.089s | 18.6x |
| after #24 | 0.580s | 9.8x |
| this PR | **0.093s** | **1.6x** |

So #24's "68.8x → 40.4x" should have read "18.6x → 9.8x", and a page-by-page lap over the collection now costs about 1.5 full scans instead of ten.

**The change.** New `NitriteMapProvider::skip_keys_from_start`, defaulted to `None` so every other backend keeps the walk and stays correct without implementing anything. Only the key it stops on is decoded; the ones stepped over never become `Key`s.

The fjall implementation **declines while a transaction is in scope**. The keys visible there include the scope's uncommitted inserts and exclude its tombstones — that is what `visible_entry_raw` merges entry by entry — and a count over the committed partition alone would land on the wrong row. Returning `None` falls back to the merge, which is slower and correct.

**What I tried first and backed out**, in case it comes up again: a general `scan()` cursor returning a full entry iterator. It was *worse* — 55.5x — because fjall's `iter()` reads values off disk even when they are dropped, while `higher_key` reads only keys, so a cursor made skipping more expensive rather than less. It also had a real bug: it decoded a `Slice` where the working code decodes a `Vec<u8>`, which blew up as `unknown type tag 0x12` on the first drained scan. A keys-only skip is the shape that actually fits an LSM.

Tests: the existing `collection::paging_test` covers this — every page against the slice of the full scan it claims to be, a page past the end, the edges of the skip, an indexed query, and the three shapes that must decline the push-down. 2267 unit + 683 integration green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved document skipping when starting at the beginning of a map by efficiently advancing through keys without reading each value.
  * Retained a compatible fallback for stores that do not support optimized skipping.

* **Bug Fixes**
  * Ensured skipping remains accurate when transaction-scoped changes cannot be included in the optimized traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->